### PR TITLE
Add simplified requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+python-dotenv==1.0.1
+google-adk==1.0.0
+immutabledict==4.2.1
+sqlglot==26.10.1
+db-dtypes==1.4.2
+regex==2024.11.6
+tabulate==0.9.0
+pandas==2.2
+openpyxl==3.1
+google-cloud-aiplatform[adk,agent-engines]==1.93.0
+absl-py==2.2.2
+pydantic==2.11.3


### PR DESCRIPTION
## Summary
- regenerate `requirements.txt` using direct dependencies from `pyproject.toml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_68459df89758832683c724273431983d